### PR TITLE
Alter VLT templating for DellOS10 to include more parameters

### DIFF
--- a/templates/dellos10_vlt.j2
+++ b/templates/dellos10_vlt.j2
@@ -31,6 +31,30 @@ vlt-domain {{ dellos_vlt.domain }}
  discovery-interface ethernet{{ dellos_vlt.discovery_intf }}
       {% endif %}
     {% endif %}
+    {% if dellos_vlt.backup_destination is defined %}
+      {% if dellos_vlt.backup_destination %}
+        {% if dellos_vlt.destination_type is defined %}
+          {% if dellos_vlt.destination_type == 'ipv6' %}
+ backup destination ipv6 {{ dellos_vlt.backup_destination }}
+          {% elif dellos_vlt.destination_type ==  'ipv4' %}
+            {% if dellos_vlt.backup_destination_vrf is defined and dellos_vlt.backup_destination_vrf %}
+ backup destination {{ dellos_vlt.backup_destination }} vrf {{ dellos_vlt.backup_destination_vrf }}
+            {% else %}
+ backup destination {{ dellos_vlt.backup_destination }}
+            {% endif %}
+          {% endif %}
+        {% endif %}
+      {% else %}
+ no backup destination
+      {% endif %}
+    {% endif %}
+    {% if dellos_vlt.priority is defined %}
+      {% if dellos_vlt.priority %}
+ primary-priority {{ dellos_vlt.priority }}
+      {% else %}
+ no primary-priority
+      {% endif %}
+    {% endif %}
     {% if dellos_vlt.peer_routing is defined %}
       {% if dellos_vlt.peer_routing %}
  peer-routing


### PR DESCRIPTION
Allow for specifying backup destination and primary priority for a DellOS10 switch using the VLT role, as for a DellOS9 switch